### PR TITLE
CHANGE main types like Point, Vector, Polyline are moved to compas na…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.5.0] 2024-01-10
+
+### Added
+
+### Changed
+* The main include types like `Point`, `Vector`, `Polyline` and etc. are placed to the `compas` namespace because these names are very generic. For example if you want to run CGAL normal estimation, you get a clash with Windows Polyline class (the same name).
+
+### Removed
+
 
 ## [0.5.0] 2022-10-07
 

--- a/include/compas.h
+++ b/include/compas.h
@@ -12,16 +12,16 @@
 #include <CGAL/Polyhedron_incremental_builder_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 
-using Kernel = CGAL::Exact_predicates_inexact_constructions_kernel;
-using Point = Kernel::Point_3;
-using Vector = Kernel::Vector_3;
-using Polyline = std::vector<Point>;
-using Polylines = std::list<Polyline>;
-using Polyhedron = CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3>;
-using Mesh = CGAL::Surface_mesh<Point>;
 
 namespace compas
 {
+    using Kernel = CGAL::Exact_predicates_inexact_constructions_kernel;
+    using Point = Kernel::Point_3;
+    using Vector = Kernel::Vector_3;
+    using Polyline = std::vector<Point>;
+    using Polylines = std::list<Polyline>;
+    using Polyhedron = CGAL::Polyhedron_3<Kernel, CGAL::Polyhedron_items_with_id_3>;
+    using Mesh = CGAL::Surface_mesh<Point>;
     using RowMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
     using RowMatrixXi = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 
@@ -31,13 +31,13 @@ namespace compas
 
     Mesh ngon_from_vertices_and_faces(const RowMatrixXd &V, const std::vector<std::vector<int>> &faces);
 
-    std::tuple<compas::RowMatrixXd, compas::RowMatrixXi> mesh_to_vertices_and_faces(const Mesh &mesh);
+    std::tuple< RowMatrixXd,  RowMatrixXi> mesh_to_vertices_and_faces(const Mesh &mesh);
 
-    std::tuple<compas::RowMatrixXd, compas::RowMatrixXi> quadmesh_to_vertices_and_faces(const Mesh &mesh);
+    std::tuple< RowMatrixXd,  RowMatrixXi> quadmesh_to_vertices_and_faces(const Mesh &mesh);
 
-    std::vector<compas::RowMatrixXd> polylines_to_lists_of_points(Polylines polylines);
+    std::vector< RowMatrixXd> polylines_to_lists_of_points(Polylines polylines);
 
-    std::tuple<compas::RowMatrixXd, compas::RowMatrixXi> polyhedron_to_vertices_and_faces(Polyhedron polyhedron);
+    std::tuple< RowMatrixXd,  RowMatrixXi> polyhedron_to_vertices_and_faces(Polyhedron polyhedron);
 }
 
 #endif /* COMPAS_H */

--- a/src/booleans.cpp
+++ b/src/booleans.cpp
@@ -11,9 +11,9 @@ pmp_boolean_union(
     Eigen::Ref<const compas::RowMatrixXd> &VB,
     Eigen::Ref<const compas::RowMatrixXi> &FB)
 {
-    Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
-    Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
-    Mesh C;
+    compas::Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
+    compas::Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
+    compas::Mesh C;
 
     PMP::corefine_and_compute_union(A, B, C);
 
@@ -31,9 +31,9 @@ pmp_boolean_difference(
     Eigen::Ref<const compas::RowMatrixXd> &VB,
     Eigen::Ref<const compas::RowMatrixXi> &FB)
 {
-    Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
-    Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
-    Mesh C;
+    compas::Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
+    compas::Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
+    compas::Mesh C;
 
     PMP::corefine_and_compute_difference(A, B, C);
 
@@ -51,9 +51,9 @@ pmp_boolean_intersection(
     Eigen::Ref<const compas::RowMatrixXd> &VB,
     Eigen::Ref<const compas::RowMatrixXi> &FB)
 {
-    Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
-    Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
-    Mesh C;
+    compas::Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
+    compas::Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
+    compas::Mesh C;
 
     PMP::corefine_and_compute_intersection(A, B, C);
 
@@ -71,8 +71,8 @@ pmp_split(
     Eigen::Ref<const compas::RowMatrixXd> &VB,
     Eigen::Ref<const compas::RowMatrixXi> &FB)
 {
-    Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
-    Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
+    compas::Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
+    compas::Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
     PMP::split(A, B);
 
     std::tuple<compas::RowMatrixXd, compas::RowMatrixXi> R = compas::mesh_to_vertices_and_faces(A);

--- a/src/compas.cpp
+++ b/src/compas.cpp
@@ -46,16 +46,16 @@ public:
  *
  * @param V vx3 matrix of vertex coordinates.
  * @param F fx3 matrix of face vertex indices.
- * @return Polyhedron
+ * @return compas::Polyhedron
  *
  * @todo: add support for Ngon faces.
  */
-Polyhedron polyhedron_from_vertices_and_faces(
+compas::Polyhedron compas::polyhedron_from_vertices_and_faces(
     const compas::RowMatrixXd &V,
     const compas::RowMatrixXi &F)
 {
-    Polyhedron polyhedron;
-    Build_polyhedron<Polyhedron::HalfedgeDS> build(V, F);
+    compas::Polyhedron polyhedron;
+    Build_polyhedron<compas::Polyhedron::HalfedgeDS> build(V, F);
     polyhedron.delegate(build);
     return polyhedron;
 }
@@ -65,31 +65,31 @@ Polyhedron polyhedron_from_vertices_and_faces(
  *
  * @param V vx3 matrix of vertex coordinates.
  * @param F fx3 matrix of face vertex indices.
- * @return Mesh
+ * @return compas::Mesh
  *
  * @todo: change name to trimesh_from_vertices_and_faces.
  * @todo: check that all faces are triangles.
  * @todo: add error message if not all faces are triangles.
  *
  */
-Mesh compas::mesh_from_vertices_and_faces(
+compas::Mesh compas::mesh_from_vertices_and_faces(
     const compas::RowMatrixXd &V,
     const compas::RowMatrixXi &F)
 {
     int v = V.rows();
     int f = F.rows();
 
-    Mesh mesh;
-    std::vector<Mesh::Vertex_index> index_descriptor(v);
+    compas::Mesh mesh;
+    std::vector<compas::Mesh::Vertex_index> index_descriptor(v);
 
     for (int i = 0; i < v; i++)
     {
-        index_descriptor[i] = mesh.add_vertex(Kernel::Point_3(V(i, 0), V(i, 1), V(i, 2)));
+        index_descriptor[i] = mesh.add_vertex(compas::Kernel::Point_3(V(i, 0), V(i, 1), V(i, 2)));
     }
 
-    Mesh::Vertex_index a;
-    Mesh::Vertex_index b;
-    Mesh::Vertex_index c;
+    compas::Mesh::Vertex_index a;
+    compas::Mesh::Vertex_index b;
+    compas::Mesh::Vertex_index c;
 
     for (int i = 0; i < f; i++)
     {
@@ -107,27 +107,27 @@ Mesh compas::mesh_from_vertices_and_faces(
  *
  * @param V nx3 matrix of vertex coordinates.
  * @param faces list of list of vertex indices.
- * @return Mesh
+ * @return compas::Mesh
  *
  * @todo: rename to mesh_from_vertices_and_faces.
  */
-Mesh compas::ngon_from_vertices_and_faces(
+compas::Mesh compas::ngon_from_vertices_and_faces(
     const compas::RowMatrixXd &V,
     const std::vector<std::vector<int>> &faces)
 {
     int v = V.rows();
 
-    Mesh mesh;
-    std::vector<Mesh::Vertex_index> index_descriptor(v);
+    compas::Mesh mesh;
+    std::vector<compas::Mesh::Vertex_index> index_descriptor(v);
 
     for (int i = 0; i < v; i++)
     {
-        index_descriptor[i] = mesh.add_vertex(Kernel::Point_3(V(i, 0), V(i, 1), V(i, 2)));
+        index_descriptor[i] = mesh.add_vertex(compas::Kernel::Point_3(V(i, 0), V(i, 1), V(i, 2)));
     }
 
     for (std::size_t i = 0; i < faces.size(); i++)
     {
-        std::vector<Mesh::Vertex_index> face;
+        std::vector<compas::Mesh::Vertex_index> face;
 
         for (std::size_t j = 0; j < faces[i].size(); j++)
         {
@@ -153,7 +153,7 @@ Mesh compas::ngon_from_vertices_and_faces(
  */
 std::tuple<compas::RowMatrixXd, compas::RowMatrixXi>
 compas::mesh_to_vertices_and_faces(
-    const Mesh &mesh)
+    const compas::Mesh &mesh)
 {
     std::size_t v = mesh.number_of_vertices();
     std::size_t f = mesh.number_of_faces();
@@ -161,19 +161,19 @@ compas::mesh_to_vertices_and_faces(
     compas::RowMatrixXd V(v, 3);
     compas::RowMatrixXi F(f, 3);
 
-    Mesh::Property_map<Mesh::Vertex_index, Kernel::Point_3> location = mesh.points();
+    compas::Mesh::Property_map<compas::Mesh::Vertex_index, compas::Kernel::Point_3> location = mesh.points();
 
-    for (Mesh::Vertex_index vd : mesh.vertices())
+    for (compas::Mesh::Vertex_index vd : mesh.vertices())
     {
         V(vd, 0) = (double)location[vd][0];
         V(vd, 1) = (double)location[vd][1];
         V(vd, 2) = (double)location[vd][2];
     }
 
-    for (Mesh::Face_index fd : mesh.faces())
+    for (compas::Mesh::Face_index fd : mesh.faces())
     {
         int i = 0;
-        for (Mesh::Vertex_index vd : vertices_around_face(mesh.halfedge(fd), mesh))
+        for (compas::Mesh::Vertex_index vd : vertices_around_face(mesh.halfedge(fd), mesh))
         {
             F(fd, i) = (int)vd;
             i++;
@@ -196,7 +196,7 @@ compas::mesh_to_vertices_and_faces(
  */
 std::tuple<compas::RowMatrixXd, compas::RowMatrixXi>
 compas::quadmesh_to_vertices_and_faces(
-    const Mesh &mesh)
+    const compas::Mesh &mesh)
 {
     std::size_t v = mesh.number_of_vertices();
     std::size_t f = mesh.number_of_faces();
@@ -204,19 +204,19 @@ compas::quadmesh_to_vertices_and_faces(
     compas::RowMatrixXd V(v, 3);
     compas::RowMatrixXi F(f, 4);
 
-    Mesh::Property_map<Mesh::Vertex_index, Kernel::Point_3> vertex_location = mesh.points();
+    compas::Mesh::Property_map<compas::Mesh::Vertex_index, compas::Kernel::Point_3> vertex_location = mesh.points();
 
-    for (Mesh::Vertex_index vd : mesh.vertices())
+    for (compas::Mesh::Vertex_index vd : mesh.vertices())
     {
         V(vd, 0) = (double)vertex_location[vd][0];
         V(vd, 1) = (double)vertex_location[vd][1];
         V(vd, 2) = (double)vertex_location[vd][2];
     }
 
-    for (Mesh::Face_index fd : mesh.faces())
+    for (compas::Mesh::Face_index fd : mesh.faces())
     {
         int i = 0;
-        for (Mesh::Vertex_index vd : vertices_around_face(mesh.halfedge(fd), mesh))
+        for (compas::Mesh::Vertex_index vd : vertices_around_face(mesh.halfedge(fd), mesh))
         {
             F(fd, i) = (int)vd;
             i++;
@@ -235,13 +235,13 @@ compas::quadmesh_to_vertices_and_faces(
  */
 std::vector<compas::RowMatrixXd>
 compas::polylines_to_lists_of_points(
-    Polylines polylines)
+    compas::Polylines polylines)
 {
     std::vector<compas::RowMatrixXd> pointsets;
 
     for (auto i = polylines.begin(); i != polylines.end(); i++)
     {
-        const Polyline &poly = *i;
+        const compas::Polyline &poly = *i;
         std::size_t n = poly.size();
         compas::RowMatrixXd points(n, 3);
 
@@ -268,7 +268,7 @@ compas::polylines_to_lists_of_points(
  */
 std::tuple<compas::RowMatrixXd, compas::RowMatrixXi>
 compas::polyhedron_to_vertices_and_faces(
-    Polyhedron polyhedron)
+    compas::Polyhedron polyhedron)
 {
     std::size_t v = polyhedron.size_of_vertices();
     std::size_t f = polyhedron.size_of_facets();
@@ -278,7 +278,7 @@ compas::polyhedron_to_vertices_and_faces(
 
     std::size_t i = 0;
 
-    for (Polyhedron::Vertex_handle vh : polyhedron.vertex_handles())
+    for (compas::Polyhedron::Vertex_handle vh : polyhedron.vertex_handles())
     {
         V(i, 0) = (double)vh->point().x();
         V(i, 1) = (double)vh->point().y();
@@ -291,11 +291,11 @@ compas::polyhedron_to_vertices_and_faces(
 
     i = 0;
 
-    for (Polyhedron::Facet_handle fh : polyhedron.facet_handles())
+    for (compas::Polyhedron::Facet_handle fh : polyhedron.facet_handles())
     {
         std::size_t j = 0;
 
-        Polyhedron::Halfedge_handle start = fh->halfedge(), h = start;
+        compas::Polyhedron::Halfedge_handle start = fh->halfedge(), h = start;
         do
         {
             F(i, j) = h->vertex()->id();

--- a/src/intersections.cpp
+++ b/src/intersections.cpp
@@ -10,10 +10,10 @@ pmp_intersection_mesh_mesh(
     Eigen::Ref<const compas::RowMatrixXd> &VB,
     Eigen::Ref<const compas::RowMatrixXi> &FB)
 {
-    Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
-    Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
+    compas::Mesh A = compas::mesh_from_vertices_and_faces(VA, FA);
+    compas::Mesh B = compas::mesh_from_vertices_and_faces(VB, FB);
 
-    Polylines polylines;
+    compas::Polylines polylines;
 
     PMP::surface_intersection(A, B, std::back_inserter(polylines));
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -9,7 +9,7 @@ pmp_area(
     Eigen::Ref<const compas::RowMatrixXd> &V,
     Eigen::Ref<const compas::RowMatrixXi> &F)
 {
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
     double area = PMP::area(mesh);
 
@@ -21,7 +21,7 @@ pmp_volume(
     Eigen::Ref<const compas::RowMatrixXd> &V,
     Eigen::Ref<const compas::RowMatrixXi> &F)
 {
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
     double volume = PMP::volume(mesh);
 
@@ -33,9 +33,9 @@ pmp_centroid(
     Eigen::Ref<const compas::RowMatrixXd> &V,
     Eigen::Ref<const compas::RowMatrixXi> &F)
 {
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
-    Kernel::Point_3 centroid = PMP::centroid(mesh);
+    compas::Kernel::Point_3 centroid = PMP::centroid(mesh);
 
     return std::vector<double>{centroid.x(), centroid.y(), centroid.z()};
 };

--- a/src/meshing.cpp
+++ b/src/meshing.cpp
@@ -14,11 +14,11 @@ pmp_remesh(
     unsigned int number_of_iterations,
     bool do_project)
 {
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
     // protect sharp features
 
-    // typedef boost::property_map<Mesh, CGAL::edge_is_feature_t>::type EIFMap;
+    // typedef boost::property_map<compas::Mesh, CGAL::edge_is_feature_t>::type EIFMap;
     // EIFMap eif = get(CGAL::edge_is_feature, mesh);
     // PMP::detect_sharp_edges(mesh, 60, eif);
 

--- a/src/reconstruction.cpp
+++ b/src/reconstruction.cpp
@@ -3,7 +3,7 @@
 #include <CGAL/property_map.h>
 #include <CGAL/remove_outliers.h>
 
-typedef std::pair<Point, Vector> PwN;
+typedef std::pair<compas::Point, compas::Vector> PwN;
 
 /**
  * @brief Perform Poisson surface reconstruction on an oriented pointcloud with normals.
@@ -17,14 +17,14 @@ poisson_surface_reconstruction(
     Eigen::Ref<const compas::RowMatrixXd> &P,
     Eigen::Ref<const compas::RowMatrixXd> &N)
 {
-    Polyhedron mesh;
+    compas::Polyhedron mesh;
     std::vector<PwN> points;
 
     for (int i = 0; i < P.rows(); i++)
     {
         points.push_back(PwN(
-            Point(P(i, 0), P(i, 1), P(i, 2)),
-            Vector(N(i, 0), N(i, 1), N(i, 2))));
+            compas::Point(P(i, 0), P(i, 1), P(i, 2)),
+            compas::Vector(N(i, 0), N(i, 1), N(i, 2))));
     }
 
     double average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>(
@@ -59,16 +59,16 @@ pointset_outlier_removal(
     double radius)
 {
     int p = P.rows();
-    std::vector<Point> points;
+    std::vector<compas::Point> points;
 
     for (int i = 0; i < p; i++)
     {
-        points.push_back(Point(P(i, 0), P(i, 1), P(i, 2)));
+        points.push_back(compas::Point(P(i, 0), P(i, 1), P(i, 2)));
     }
 
     const double average_spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag>(points, nnnbrs);
 
-    std::vector<Point>::iterator to_remove = CGAL::remove_outliers<CGAL::Parallel_if_available_tag>(
+    std::vector<compas::Point>::iterator to_remove = CGAL::remove_outliers<CGAL::Parallel_if_available_tag>(
         points,
         nnnbrs,
         CGAL::parameters::threshold_percent(100.).threshold_distance(radius * average_spacing));
@@ -83,7 +83,7 @@ pointset_outlier_removal(
     // return outliers;
 
     points.erase(to_remove, points.end());
-    std::vector<Point>(points).swap(points);
+    std::vector<compas::Point>(points).swap(points);
 
     std::size_t s = points.size();
     compas::RowMatrixXd result(s, 3);

--- a/src/skeletonization.cpp
+++ b/src/skeletonization.cpp
@@ -2,10 +2,10 @@
 #include <CGAL/Mean_curvature_flow_skeletonization.h>
 #include <CGAL/boost/graph/split_graph_into_polylines.h>
 
-typedef CGAL::Mean_curvature_flow_skeletonization<Mesh> Skeletonization;
+typedef CGAL::Mean_curvature_flow_skeletonization<compas::Mesh> Skeletonization;
 typedef Skeletonization::Skeleton Skeleton;
 
-typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
+typedef boost::graph_traits<compas::Mesh>::vertex_descriptor vertex_descriptor;
 
 typedef Skeleton::vertex_descriptor Skeleton_vertex;
 typedef Skeleton::edge_descriptor Skeleton_edge;
@@ -13,19 +13,19 @@ typedef Skeleton::edge_descriptor Skeleton_edge;
 struct Split_polylines
 {
     const Skeleton &skeleton;
-    Polylines &polylines;
-    Polyline polyline;
+    compas::Polylines &polylines;
+    compas::Polyline polyline;
     int polyline_index = 0;
     int polyline_size;
 
-    Split_polylines(const Skeleton &skeleton, Polylines &polylines)
+    Split_polylines(const Skeleton &skeleton, compas::Polylines &polylines)
         : skeleton(skeleton), polylines(polylines)
     {
     }
 
     void start_new_polyline()
     {
-        polyline = Polyline();
+        polyline = compas::Polyline();
     }
 
     void add_node(Skeleton_vertex v)
@@ -44,7 +44,7 @@ Edges pmp_mesh_skeleton(
     Eigen::Ref<const compas::RowMatrixXi> &F)
 {
 
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
     Skeleton skeleton;
     Skeletonization mcs(mesh);
@@ -59,7 +59,7 @@ Edges pmp_mesh_skeleton(
     mcs.contract_until_convergence();
     mcs.convert_to_skeleton(skeleton);
 
-    // Polylines polylines;
+    // compas::Polylines polylines;
     // Split_polylines splitter(skeleton, polylines);
     // CGAL::split_graph_into_polylines(skeleton, splitter);
 
@@ -67,8 +67,8 @@ Edges pmp_mesh_skeleton(
 
     for (Skeleton_edge e : CGAL::make_range(edges(skeleton)))
     {
-        const Kernel::Point_3 &s = skeleton[source(e, skeleton)].point;
-        const Kernel::Point_3 &t = skeleton[target(e, skeleton)].point;
+        const compas::Kernel::Point_3 &s = skeleton[source(e, skeleton)].point;
+        const compas::Kernel::Point_3 &t = skeleton[target(e, skeleton)].point;
 
         std::vector<double> s_vec = {s.x(), s.y(), s.z()};
         std::vector<double> t_vec = {t.x(), t.y(), t.z()};

--- a/src/slicer.cpp
+++ b/src/slicer.cpp
@@ -8,19 +8,19 @@ pmp_slice_mesh(
     Eigen::Ref<const compas::RowMatrixXd> &P,
     Eigen::Ref<const compas::RowMatrixXd> &N)
 {
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
-    CGAL::Polygon_mesh_slicer<Mesh, Kernel> slicer(mesh);
-    Polylines polylines;
-    std::back_insert_iterator<Polylines> slices(polylines);
+    CGAL::Polygon_mesh_slicer<compas::Mesh, compas::Kernel> slicer(mesh);
+    compas::Polylines polylines;
+    std::back_insert_iterator<compas::Polylines> slices(polylines);
 
     int number_of_planes = P.rows();
 
     for (int i = 0; i < number_of_planes; i++)
     {
-        Kernel::Plane_3 plane = Kernel::Plane_3(
-            Kernel::Point_3(P(i, 0), P(i, 1), P(i, 2)),
-            Kernel::Vector_3(N(i, 0), N(i, 1), N(i, 2)));
+        compas::Kernel::Plane_3 plane = compas::Kernel::Plane_3(
+            compas::Kernel::Point_3(P(i, 0), P(i, 1), P(i, 2)),
+            compas::Kernel::Vector_3(N(i, 0), N(i, 1), N(i, 2)));
 
         slicer(plane, slices);
     }

--- a/src/subdivision.cpp
+++ b/src/subdivision.cpp
@@ -7,7 +7,7 @@ subd_catmullclark(
     std::vector<std::vector<int>> &faces,
     unsigned int k)
 {
-    Mesh mesh = compas::ngon_from_vertices_and_faces(V, faces);
+    compas::Mesh mesh = compas::ngon_from_vertices_and_faces(V, faces);
 
     CGAL::Subdivision_method_3::CatmullClark_subdivision(mesh, CGAL::parameters::number_of_iterations(k));
 
@@ -23,7 +23,7 @@ subd_loop(
     compas::RowMatrixXi &F,
     unsigned int k)
 {
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
     CGAL::Subdivision_method_3::Loop_subdivision(mesh, CGAL::parameters::number_of_iterations(k));
 
@@ -39,7 +39,7 @@ subd_sqrt3(
     compas::RowMatrixXi &F,
     unsigned int k)
 {
-    Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
+    compas::Mesh mesh = compas::mesh_from_vertices_and_faces(V, F);
 
     CGAL::Subdivision_method_3::Sqrt3_subdivision(mesh, CGAL::parameters::number_of_iterations(k));
 

--- a/src/triangulations.cpp
+++ b/src/triangulations.cpp
@@ -25,23 +25,23 @@ struct FaceInfo
     }
 };
 
-using Polygon = CGAL::Polygon_2<Kernel>;
+using Polygon = CGAL::Polygon_2<compas::Kernel>;
 
-using VertexBase1 = CGAL::Triangulation_vertex_base_with_info_2<unsigned, Kernel>;
+using VertexBase1 = CGAL::Triangulation_vertex_base_with_info_2<unsigned, compas::Kernel>;
 using TDS1 = CGAL::Triangulation_data_structure_2<VertexBase1>;
-using DT = CGAL::Delaunay_triangulation_2<Kernel, TDS1>;
+using DT = CGAL::Delaunay_triangulation_2<compas::Kernel, TDS1>;
 
-using VertexBase2 = CGAL::Triangulation_vertex_base_2<Kernel>;
-using _FaceBase2 = CGAL::Triangulation_face_base_with_info_2<FaceInfo, Kernel>;
-using FaceBase2 = CGAL::Constrained_triangulation_face_base_2<Kernel, _FaceBase2>;
+using VertexBase2 = CGAL::Triangulation_vertex_base_2<compas::Kernel>;
+using _FaceBase2 = CGAL::Triangulation_face_base_with_info_2<FaceInfo, compas::Kernel>;
+using FaceBase2 = CGAL::Constrained_triangulation_face_base_2<compas::Kernel, _FaceBase2>;
 using TDS2 = CGAL::Triangulation_data_structure_2<VertexBase2, FaceBase2>;
-using CDT2 = CGAL::Constrained_Delaunay_triangulation_2<Kernel, TDS2>;
+using CDT2 = CGAL::Constrained_Delaunay_triangulation_2<compas::Kernel, TDS2>;
 
-using VertexBase3 = CGAL::Delaunay_mesh_vertex_base_2<Kernel>;
-using FaceBase3 = CGAL::Delaunay_mesh_face_base_2<Kernel>;
+using VertexBase3 = CGAL::Delaunay_mesh_vertex_base_2<compas::Kernel>;
+using FaceBase3 = CGAL::Delaunay_mesh_face_base_2<compas::Kernel>;
 using TDS3 = CGAL::Triangulation_data_structure_2<VertexBase3, FaceBase3>;
 using Itag = CGAL::Exact_predicates_tag;
-using CDT3 = CGAL::Constrained_Delaunay_triangulation_2<Kernel, TDS3, Itag>;
+using CDT3 = CGAL::Constrained_Delaunay_triangulation_2<compas::Kernel, TDS3, Itag>;
 using Criteria = CGAL::Delaunay_mesh_size_criteria_2<CDT3>;
 
 // ===========================================================================
@@ -327,7 +327,7 @@ pmp_constrained_delaunay_triangulation(
 // ===========================================================================
 // ===========================================================================
 // ===========================================================================
-// Constrained Delaunay Mesh
+// Constrained Delaunay compas::Mesh
 // ===========================================================================
 // ===========================================================================
 // ===========================================================================


### PR DESCRIPTION
The main types like `Point`, `Vector`, `Polyline` and etc. are placed to the `compas` namespace because these names are very generic. For example if you want to run CGAL normal estimation, you get a clash with Windows Polyline class (the same name).