### PR TITLE
Changing straight skeleton return data into `Graph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+### Added
+
+### Changed
+
+* Changed the return values of `compas_cgal.straight_skeleton_2.create_interior_straight_skeleton` and `compas_cgal.straight_skeleton_2.create_interior_straight_skeleton_with_holes` into graph data.
+
+### Removed
+
+
 ## [0.7.0] 2024-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Changed the return values of `compas_cgal.straight_skeleton_2.create_interior_straight_skeleton` and `compas_cgal.straight_skeleton_2.create_interior_straight_skeleton_with_holes` into graph data.
+* Changed the return values of `compas_cgal.straight_skeleton_2.create_interior_straight_skeleton` and `compas_cgal.straight_skeleton_2.create_interior_straight_skeleton_with_holes`.
+* Changed the return values of `compas_cgal.create_interior_straight_skeleton`.
 
 ### Removed
 

--- a/docs/examples/straight_skeleton_2.py
+++ b/docs/examples/straight_skeleton_2.py
@@ -1,5 +1,4 @@
-from compas.datastructures import Graph
-from compas.geometry import Polygon
+from compas.geometry import Line
 from compas_cgal.straight_skeleton_2 import create_interior_straight_skeleton
 from compas_viewer import Viewer
 
@@ -15,15 +14,22 @@ points = [
     (2.92, 4.03, 0.0),
     (-1.91, 3.59, 0.0),
 ]
-polygon = Polygon(points)
-lines = create_interior_straight_skeleton(points)
-graph = Graph.from_lines(lines)
+
+
+graph = create_interior_straight_skeleton(points)
 
 # ==============================================================================
 # Viz
 # ==============================================================================
 
 viewer = Viewer(width=1600, height=900)
-viewer.scene.add(graph, edgecolor=(1.0, 0.0, 0.0))
-viewer.scene.add(polygon)
+for edge in graph.edges():
+    line = Line(*graph.edge_coordinates(edge))
+    if graph.edge_attribute(edge, "inner_bisector"):
+        print(edge, "inner_bisector")
+        viewer.add(line, linecolor=(1.0, 0.0, 0.0), linewidth=2)
+    elif graph.edge_attribute(edge, "bisector"):
+        viewer.add(line, linecolor=(0.0, 0.0, 1.0))
+    else:
+        viewer.add(line, linecolor=(0.0, 0.0, 0.0))
 viewer.show()

--- a/docs/examples/straight_skeleton_2.py
+++ b/docs/examples/straight_skeleton_2.py
@@ -1,4 +1,3 @@
-from compas.geometry import Line
 from compas_cgal.straight_skeleton_2 import create_interior_straight_skeleton
 from compas_viewer import Viewer
 
@@ -24,7 +23,7 @@ graph = create_interior_straight_skeleton(points)
 
 viewer = Viewer(width=1600, height=900)
 for edge in graph.edges():
-    line = Line(*graph.edge_coordinates(edge))
+    line = graph.edge_line(edge)
     if graph.edge_attribute(edge, "inner_bisector"):
         print(edge, "inner_bisector")
         viewer.add(line, linecolor=(1.0, 0.0, 0.0), linewidth=2)

--- a/docs/examples/straight_skeleton_2_holes.py
+++ b/docs/examples/straight_skeleton_2_holes.py
@@ -1,5 +1,4 @@
-from compas.datastructures import Graph
-from compas.geometry import Polygon
+from compas.geometry import Polygon, Line
 from compas_viewer import Viewer
 
 from compas_cgal.straight_skeleton_2 import create_interior_straight_skeleton_with_holes
@@ -26,17 +25,20 @@ holes = [
 
 polygon = Polygon(points)
 holes = [Polygon(hole) for hole in holes]
-lines = create_interior_straight_skeleton_with_holes(polygon, holes)
-graph = Graph.from_lines(lines)
+graph = create_interior_straight_skeleton_with_holes(polygon, holes)
 
 # ==============================================================================
 # Viz
 # ==============================================================================
 
 viewer = Viewer(width=1600, height=900)
-viewer.renderer_config.show_grid = False
-viewer.scene.add(graph, edgecolor=(1.0, 0.0, 0.0))
-viewer.scene.add(polygon)
-for hole in holes:
-    viewer.scene.add(hole)
+
+for edge in graph.edges():
+    line = Line(*graph.edge_coordinates(edge))
+    if graph.edge_attribute(edge, "inner_bisector"):
+        viewer.add(line, linecolor=(1.0, 0.0, 0.0), linewidth=2)
+    elif graph.edge_attribute(edge, "bisector"):
+        viewer.add(line, linecolor=(0.0, 0.0, 1.0))
+    else:
+        viewer.add(line, linecolor=(0.0, 0.0, 0.0))
 viewer.show()

--- a/docs/examples/straight_skeleton_2_holes.py
+++ b/docs/examples/straight_skeleton_2_holes.py
@@ -1,4 +1,4 @@
-from compas.geometry import Polygon, Line
+from compas.geometry import Polygon
 from compas_viewer import Viewer
 
 from compas_cgal.straight_skeleton_2 import create_interior_straight_skeleton_with_holes
@@ -34,7 +34,7 @@ graph = create_interior_straight_skeleton_with_holes(polygon, holes)
 viewer = Viewer(width=1600, height=900)
 
 for edge in graph.edges():
-    line = Line(*graph.edge_coordinates(edge))
+    line = graph.edge_line(edge)
     if graph.edge_attribute(edge, "inner_bisector"):
         viewer.add(line, linecolor=(1.0, 0.0, 0.0), linewidth=2)
     elif graph.edge_attribute(edge, "bisector"):

--- a/src/compas_cgal/straight_skeleton_2.py
+++ b/src/compas_cgal/straight_skeleton_2.py
@@ -102,7 +102,7 @@ def create_interior_straight_skeleton_with_holes(points, holes) -> Graph:
             raise ValueError("The normal of the hole should be [0, 0, -1]. The normal of the provided {}-th hole is {}".format(i, normal_hole))
         hole = np.asarray(points, dtype=np.float64)
         H.append(hole)
-    return graph_from_skeleton_data(straight_skeleton_2.create_interior_straight_skeleton_with_holes(V, H))
+    return graph_from_skeleton_data(*straight_skeleton_2.create_interior_straight_skeleton_with_holes(V, H))
 
 
 def create_offset_polygons_2(points, offset) -> list[Polygon]:

--- a/src/compas_cgal/straight_skeleton_2.py
+++ b/src/compas_cgal/straight_skeleton_2.py
@@ -7,14 +7,30 @@ from compas.tolerance import TOL
 from compas_cgal._cgal import straight_skeleton_2
 
 
-def graph_from_skeleton_data(skeleton_data) -> Graph:
-    Mv, Mvi, Me, Mei = skeleton_data
+def graph_from_skeleton_data(points, indices, edges, edge_types) -> Graph:
+    """Create a graph from the skeleton data.
 
+    Parameters
+    ----------
+    points : list of point coordinates
+        The vertices of the skeleton.
+    indices : list of int
+        The vertex indices of the skeleton, corresponding to the points.
+    edges : list of tuple of int
+        The edges of the skeleton.
+    edge_types : list of int
+        The type per edge, `0` for inner bisector, `1` for bisector, and `2` for boundary.
+
+    Returns
+    -------
+    :class:`compas.datastructures.Graph`
+        The skeleton as a graph.
+    """
     graph = Graph()
-    for pt, i in zip(Mv, Mvi):
+    for pt, i in zip(points, indices):
         graph.add_node(key=i, x=pt[0], y=pt[1], z=pt[2])
 
-    for edge, etype in zip(Me, Mei):
+    for edge, etype in zip(edges, edge_types):
         edge = graph.add_edge(*edge)
         if etype == 0:
             graph.edge_attribute(edge, "inner_bisector", True)
@@ -48,7 +64,7 @@ def create_interior_straight_skeleton(points) -> Graph:
     if not TOL.is_allclose(normal, [0, 0, 1]):
         raise ValueError("The normal of the polygon should be [0, 0, 1]. The normal of the provided polygon is {}".format(normal))
     V = np.asarray(points, dtype=np.float64)
-    return graph_from_skeleton_data(straight_skeleton_2.create_interior_straight_skeleton(V))
+    return graph_from_skeleton_data(*straight_skeleton_2.create_interior_straight_skeleton(V))
 
 
 def create_interior_straight_skeleton_with_holes(points, holes) -> Graph:

--- a/src/compas_cgal/straight_skeleton_2.py
+++ b/src/compas_cgal/straight_skeleton_2.py
@@ -1,3 +1,6 @@
+from typing import Tuple
+from typing import Union
+
 import numpy as np
 from compas.datastructures import Graph
 from compas.geometry import Polygon
@@ -6,19 +9,23 @@ from compas.tolerance import TOL
 
 from compas_cgal._cgal import straight_skeleton_2
 
+from .types import IntNx1
+from .types import IntNx2
+from .types import VerticesNumpy
 
-def graph_from_skeleton_data(points, indices, edges, edge_types) -> Graph:
+
+def graph_from_skeleton_data(points: VerticesNumpy, indices: IntNx1, edges: IntNx2, edge_types: IntNx1) -> Graph:
     """Create a graph from the skeleton data.
 
     Parameters
     ----------
-    points : list of point coordinates
-        The vertices of the skeleton.
-    indices : list of int
+    points : :class:`numpy.ndarray`
+        The vertices of the skeleton, each vertex defined by 3 spatial coordinates.
+    indices : :class:`numpy.ndarray`
         The vertex indices of the skeleton, corresponding to the points.
-    edges : list of tuple of int
-        The edges of the skeleton.
-    edge_types : list of int
+    edges : :class:`numpy.ndarray`
+        The edges of the skeleton, each edge defined by 2 vertex indices.
+    edge_types : :class:`numpy.ndarray`
         The type per edge, `0` for inner bisector, `1` for bisector, and `2` for boundary.
 
     Returns
@@ -41,13 +48,15 @@ def graph_from_skeleton_data(points, indices, edges, edge_types) -> Graph:
     return graph
 
 
-def create_interior_straight_skeleton(points) -> Graph:
+def create_interior_straight_skeleton(points, as_graph=True) -> Union[Graph, Tuple[VerticesNumpy, IntNx1, IntNx2, IntNx1]]:
     """Compute the skeleton of a polygon.
 
     Parameters
     ----------
     points : list of point coordinates or :class:`compas.geometry.Polygon`
         The points of the polygon.
+    as_graph : bool, optional
+        Whether the skeleton should be returned as a graph, defaults to `True`.
 
     Returns
     -------
@@ -64,10 +73,13 @@ def create_interior_straight_skeleton(points) -> Graph:
     if not TOL.is_allclose(normal, [0, 0, 1]):
         raise ValueError("The normal of the polygon should be [0, 0, 1]. The normal of the provided polygon is {}".format(normal))
     V = np.asarray(points, dtype=np.float64)
-    return graph_from_skeleton_data(*straight_skeleton_2.create_interior_straight_skeleton(V))
+    points, indices, edges, edge_types = straight_skeleton_2.create_interior_straight_skeleton(V)
+    if as_graph:
+        return graph_from_skeleton_data(points, indices, edges, edge_types)
+    return points, indices, edges, edge_types
 
 
-def create_interior_straight_skeleton_with_holes(points, holes) -> Graph:
+def create_interior_straight_skeleton_with_holes(points, holes, as_graph=True) -> Union[Graph, Tuple[VerticesNumpy, IntNx1, IntNx2, IntNx1]]:
     """Compute the skeleton of a polygon with holes.
 
     Parameters
@@ -76,6 +88,8 @@ def create_interior_straight_skeleton_with_holes(points, holes) -> Graph:
         The points of the polygon.
     holes : list of list of point coordinates or list of :class:`compas.geometry.Polygon`
         The holes of the polygon.
+    as_graph : bool, optional
+        Whether the skeleton should be returned as a graph, defaults to `True`.
 
     Returns
     -------
@@ -102,7 +116,10 @@ def create_interior_straight_skeleton_with_holes(points, holes) -> Graph:
             raise ValueError("The normal of the hole should be [0, 0, -1]. The normal of the provided {}-th hole is {}".format(i, normal_hole))
         hole = np.asarray(points, dtype=np.float64)
         H.append(hole)
-    return graph_from_skeleton_data(*straight_skeleton_2.create_interior_straight_skeleton_with_holes(V, H))
+    points, indices, edges, edge_types = straight_skeleton_2.create_interior_straight_skeleton_with_holes(V, H)
+    if as_graph:
+        return graph_from_skeleton_data(points, indices, edges, edge_types)
+    return points, indices, edges, edge_types
 
 
 def create_offset_polygons_2(points, offset) -> list[Polygon]:

--- a/src/compas_cgal/straight_skeleton_2.py
+++ b/src/compas_cgal/straight_skeleton_2.py
@@ -60,7 +60,7 @@ def create_interior_straight_skeleton(points, as_graph=True) -> Union[Graph, Tup
 
     Returns
     -------
-    :attr:`compas_cgal.types.PolylinesNumpy`
+    :attr:`compas.datastructures.Graph` or tuple of (vertices, indices, edges, edge_types)
         The skeleton of the polygon.
 
     Raises
@@ -93,7 +93,7 @@ def create_interior_straight_skeleton_with_holes(points, holes, as_graph=True) -
 
     Returns
     -------
-    :attr:`compas_cgal.types.PolylinesNumpy`
+    :attr:`compas.datastructures.Graph` or tuple of (vertices, indices, edges, edge_types)
         The skeleton of the polygon.
 
     Raises

--- a/src/compas_cgal/types.py
+++ b/src/compas_cgal/types.py
@@ -12,6 +12,8 @@ from numpy.typing import NDArray
 
 FloatNx3 = Annotated[NDArray[float64], Literal["N", 3]]
 IntNx3 = Annotated[NDArray[int64], Literal["N", 3]]
+IntNx2 = Annotated[NDArray[int64], Literal["N", 2]]
+IntNx1 = Annotated[NDArray[int64], Literal["N", 1]]
 
 VerticesNumpy = FloatNx3
 """An array of vertices, with each vertex defined by 3 spatial coordinates."""

--- a/src/straight_skeleton_2.h
+++ b/src/straight_skeleton_2.h
@@ -4,11 +4,11 @@
 #include <compas.h>
 
 
-compas::Edges pmp_create_interior_straight_skeleton(
+std::tuple<compas::RowMatrixXd, std::vector<int>, compas::RowMatrixXi, std::vector<int>> pmp_create_interior_straight_skeleton(
     Eigen::Ref<const compas::RowMatrixXd> &V);
 
 
-compas::Edges pmp_create_interior_straight_skeleton_with_holes(
+std::tuple<compas::RowMatrixXd, std::vector<int>, compas::RowMatrixXi, std::vector<int>> pmp_create_interior_straight_skeleton_with_holes(
     Eigen::Ref<const compas::RowMatrixXd> &V,
     std::vector<Eigen::Ref<const compas::RowMatrixXd>> &holes);
 

--- a/tests/test_straight_skeleton_2.py
+++ b/tests/test_straight_skeleton_2.py
@@ -1,5 +1,3 @@
-from compas.tolerance import TOL
-
 from compas_cgal.straight_skeleton_2 import create_interior_straight_skeleton
 from compas_cgal.straight_skeleton_2 import create_interior_straight_skeleton_with_holes
 from compas_cgal.straight_skeleton_2 import create_offset_polygons_2
@@ -17,8 +15,8 @@ def test_straight_polygon():
         (-1, 1, 0),
         (-12, 0, 0),
     ]
-    lines = create_interior_straight_skeleton(points)
-    assert len(lines) == 8
+    graph = create_interior_straight_skeleton(points)
+    assert graph.number_of_edges() == 16
 
 
 def test_straight_skeleton_with_holes():
@@ -33,48 +31,8 @@ def test_straight_skeleton_with_holes():
         (-12, 0, 0),
     ]
     hole = [(-1, 0, 0), (0, 1, 0), (1, 0, 0), (0, -1, 0)]
-    lines = create_interior_straight_skeleton_with_holes(points, [hole])
-    assert len(lines) == 20
-
-
-def test_straight_polygon_2_compare():
-    points = [
-        (-1.91, 3.59, 0.0),
-        (-5.53, -5.22, 0.0),
-        (-0.39, -1.98, 0.0),
-        (2.98, -5.51, 0.0),
-        (4.83, -2.02, 0.0),
-        (9.70, -3.63, 0.0),
-        (12.23, 1.25, 0.0),
-        (3.42, 0.66, 0.0),
-        (2.92, 4.03, 0.0),
-        (-1.91, 3.59, 0.0),
-    ]
-    lines = create_interior_straight_skeleton(points)
-
-    expected = [
-        [[-1.91, 3.59, 0.0], [-0.139446292, 1.191439787, 0.0]],
-        [[-5.53, -5.22, 0.0], [-0.139446292, 1.191439787, 0.0]],
-        [[-0.39, -1.98, 0.0], [0.008499564, 1.241560466, 0.0]],
-        [[2.98, -5.51, 0.0], [2.44972507, -1.674799065, 0.0]],
-        [[4.83, -2.02, 0.0], [4.228131167, -0.522007766, 0.0]],
-        [[8.663865218, -1.084821998, 0.0], [9.7, -3.63, 0.0]],
-        [[12.23, 1.25, 0.0], [8.663865218, -1.084821998, 0.0]],
-        [[3.42, 0.66, 0.0], [1.755862468, -1.404991433, 0.0]],
-        [[2.92, 4.03, 0.0], [0.563706846, 1.033296141, 0.0]],
-        [[4.228131167, -0.522007766, 0.0], [2.44972507, -1.674799065, 0.0]],
-        [[4.228131167, -0.522007766, 0.0], [8.663865218, -1.084821998, 0.0]],
-        [[1.755862468, -1.404991433, 0.0], [2.44972507, -1.674799065, 0.0]],
-        [[0.563706846, 1.033296141, 0.0], [1.755862468, -1.404991433, 0.0]],
-        [[-0.139446292, 1.191439787, 0.0], [0.008499564, 1.241560466, 0.0]],
-        [[0.563706846, 1.033296141, 0.0], [0.008499564, 1.241560466, 0.0]],
-    ]
-    for act, exp in zip(lines, expected):
-        sa, ea = act
-        se, ee = exp
-        # the line direction sometimes changes ...
-        assert TOL.is_allclose(sa, se) or TOL.is_allclose(sa, ee)
-        assert TOL.is_allclose(ea, ee) or TOL.is_allclose(ea, se)
+    graph = create_interior_straight_skeleton_with_holes(points, [hole])
+    assert graph.number_of_edges() == 32
 
 
 def test_offset():


### PR DESCRIPTION
Updating the return value of straight skeleton 2 from lines to graph. This allows to include more information from the skeleton, e.g. which edges are inner bisectors, bisectors and boundary edges.