### PR TITLE
Compiled File Size Reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added build flags for file size reduction in `CMakeLists.txt`.
+
 ### Changed
 
+* Precompiled header is optional and set to OFF to reduce deployment built size.
+* Moved `compas.h` module specific headers to the individual source files.
+
 ### Removed
+
+* Remove unnecessary headers from `compas_cgal.h`.
 
 
 ## [0.7.3] 2025-03-18

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,27 @@ project(cgal_wrapper LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_FLAGS_DEBUG "")
+
+# =====================================================================
+# Set this flag to ON for developing to reduce build time.
+# Set this flag to OFF for publishing for file size reduction.
+# =====================================================================
+option(ENABLE_PRECOMPILED_HEADERS "Enable precompiled headers for the build" OFF)
+
+# =====================================================================
+# Build size reduction.
+# =====================================================================
+
+if (NOT ENABLE_PRECOMPILED_HEADERS)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    if(MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O1") # Optimize for size on MSVC
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os") # Optimize for size on GCC/Clang
+    endif()
+endif()
 
 # =====================================================================
 # Dependencies
@@ -196,15 +217,17 @@ target_include_directories(compas_cgal_ext PRIVATE
 # Make sure external dependencies are downloaded before building the extension
 add_dependencies(compas_cgal_ext external_downloads)
 
-# Enhanced PCH configuration
-set(CMAKE_PCH_INSTANTIATE_TEMPLATES OFF)
-set(CMAKE_PCH_WARN_INVALID OFF)
+if (ENABLE_PRECOMPILED_HEADERS)
+    # Enhanced PCH configuration
+    set(CMAKE_PCH_INSTANTIATE_TEMPLATES ON)
+    set(CMAKE_PCH_WARN_INVALID ON)
 
-# Configure PCH for the extension
-target_precompile_headers(compas_cgal_ext
-    PRIVATE
-    src/compas.h
-)
+    # Configure PCH for the extension
+    target_precompile_headers(compas_cgal_ext
+        PRIVATE
+        src/compas.h
+    )
+endif() 
 
 # Install directive for scikit-build-core
 install(TARGETS compas_cgal_ext LIBRARY DESTINATION compas_cgal)

--- a/src/booleans.h
+++ b/src/booleans.h
@@ -2,6 +2,10 @@
 
 #include "compas.h"
 
+// CGAL boolean
+#include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Polygon_mesh_processing/clip.h>
+
 /**
  * Compute the boolean union of two triangle meshes.
  * 

--- a/src/compas.h
+++ b/src/compas.h
@@ -5,38 +5,12 @@
 // This file is referenced in CMakeLists PCH section.
 
 // STD
-#include <stdlib.h>
 #include <vector>
-#include <array>
-#include <map>
-#include <cstdlib>
-#include <ctime>
-#include <iomanip>
-#include <algorithm>
-#include <unordered_map>
-#include <numeric>
-#include <limits>
-#include <chrono>
-#include <float.h>
-#include <inttypes.h>
-#include <cstring>
-#include <set>
-#include <unordered_set>
-#include <list>
-#include <string>
-#include <fstream>
-#include <sstream>
-#include <iostream>
-#include <filesystem>
-#include <utility>
-
 
 // Nanobind
 #include <nanobind/nanobind.h>
 #include <nanobind/eigen/dense.h>
 #include <nanobind/eigen/sparse.h>
-#include <nanobind/ndarray.h>
-#include <nanobind/stl/array.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/bind_vector.h>
 #include <nanobind/stl/shared_ptr.h>
@@ -49,7 +23,6 @@ using namespace nb::literals; // enables syntax for annotating function and argu
 #include <boost/multiprecision/cpp_dec_float.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
-
 // Eigen
 #include <Eigen/Core>
 #include <Eigen/Dense>
@@ -61,67 +34,6 @@ using namespace nb::literals; // enables syntax for annotating function and argu
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
-
-// CGAL remesh
-#include <CGAL/Polygon_mesh_processing/remesh.h>
-#include <CGAL/Polygon_mesh_processing/detect_features.h>
-
-// CGAL measure
-#include <CGAL/Polygon_mesh_processing/measure.h>
-#include <CGAL/Point_3.h>
-
-// CGAL boolean
-#include <CGAL/Polygon_mesh_processing/corefinement.h>
-#include <CGAL/Polygon_mesh_processing/clip.h>
-
-// CGAL intersection
-#include <CGAL/Polygon_mesh_processing/intersection.h>
-
-// CGAL reconstruction
-#include <CGAL/poisson_surface_reconstruction.h>
-#include <CGAL/property_map.h>
-#include <CGAL/remove_outliers.h>
-#include <CGAL/compute_average_spacing.h>
-#include <CGAL/pca_estimate_normals.h>
-#include <CGAL/mst_orient_normals.h>
-#include <CGAL/property_map.h>
-#include <CGAL/jet_smooth_point_set.h>
-#include <CGAL/Point_set_3.h>
-#include <CGAL/grid_simplify_point_set.h>
-
-// CGAL skeletonization
-#include <CGAL/Mean_curvature_flow_skeletonization.h>
-#include <CGAL/boost/graph/split_graph_into_polylines.h>
-
-// CGAL slicer
-#include <CGAL/Polygon_mesh_slicer.h>
-
-// CGAL subdivision
-#include <CGAL/subdivision_method_3.h>
-
-// CGAL triangulation
-#include <CGAL/Delaunay_triangulation_2.h>
-#include <CGAL/Constrained_triangulation_2.h>
-#include <CGAL/Constrained_Delaunay_triangulation_2.h>
-#include <CGAL/Triangulation_vertex_base_with_info_2.h>
-#include <CGAL/Triangulation_face_base_with_info_2.h>
-#include <CGAL/Polygon_2.h>
-#include <CGAL/Delaunay_mesher_2.h>
-#include <CGAL/Delaunay_mesh_vertex_base_2.h>
-#include <CGAL/Delaunay_mesh_face_base_2.h>
-#include <CGAL/Delaunay_mesh_size_criteria_2.h>
-#include <CGAL/Triangulation_conformer_2.h>
-#include <CGAL/lloyd_optimize_mesh_2.h>
-
-// CGAL straight skeleton 2
-#include <CGAL/Polygon_2.h>
-#include <CGAL/create_straight_skeleton_2.h>
-#include <CGAL/create_straight_skeleton_from_polygon_with_holes_2.h>
-#include <CGAL/create_offset_polygons_2.h>
-#include <CGAL/create_weighted_offset_polygons_from_polygon_with_holes_2.h>
-#include <CGAL/create_weighted_straight_skeleton_2.h>
-#include <CGAL/create_offset_polygons_from_polygon_with_holes_2.h>
-
 
 namespace compas
 {

--- a/src/intersections.h
+++ b/src/intersections.h
@@ -2,6 +2,9 @@
 
 #include "compas.h"
 
+// CGAL intersection
+#include <CGAL/Polygon_mesh_processing/intersection.h>
+
 /**
  * Compute intersection between two triangle meshes.
  *

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -17,6 +17,7 @@ pmp_volume(
 {
     compas::Mesh mesh = compas::mesh_from_vertices_and_faces(vertices, faces);
     double volume = CGAL::Polygon_mesh_processing::volume(mesh);
+    int a = 0;
     return volume;
 }
 

--- a/src/measure.h
+++ b/src/measure.h
@@ -2,6 +2,10 @@
 
 #include "compas.h"
 
+// CGAL measure
+#include <CGAL/Polygon_mesh_processing/measure.h>
+#include <CGAL/Point_3.h>
+
 /**
  * @brief Computes the surface area of a triangle mesh.
  * 

--- a/src/meshing.h
+++ b/src/meshing.h
@@ -1,11 +1,10 @@
-/**
- * @file meshing.h
- * @brief Header file for mesh processing operations using CGAL
- */
-
 #pragma once
 
 #include "compas.h"
+
+// CGAL remesh
+#include <CGAL/Polygon_mesh_processing/remesh.h>
+#include <CGAL/Polygon_mesh_processing/detect_features.h>
 
 namespace compas {
 

--- a/src/reconstruction.h
+++ b/src/reconstruction.h
@@ -2,6 +2,18 @@
 
 #include "compas.h"
 
+// CGAL reconstruction
+#include <CGAL/poisson_surface_reconstruction.h>
+#include <CGAL/property_map.h>
+#include <CGAL/remove_outliers.h>
+#include <CGAL/compute_average_spacing.h>
+#include <CGAL/pca_estimate_normals.h>
+#include <CGAL/mst_orient_normals.h>
+#include <CGAL/property_map.h>
+#include <CGAL/jet_smooth_point_set.h>
+#include <CGAL/Point_set_3.h>
+#include <CGAL/grid_simplify_point_set.h>
+
 /**
  * @brief Perform Poisson surface reconstruction on an oriented pointcloud with normals.
  *

--- a/src/skeletonization.h
+++ b/src/skeletonization.h
@@ -2,6 +2,10 @@
 
 #include "compas.h"
 
+// CGAL skeletonization
+#include <CGAL/Mean_curvature_flow_skeletonization.h>
+#include <CGAL/boost/graph/split_graph_into_polylines.h>
+
 /**
  * @brief Compute the geometric skeleton of a triangle mesh using mean curvature flow.
  * 

--- a/src/slicer.h
+++ b/src/slicer.h
@@ -2,6 +2,9 @@
 
 #include "compas.h"
 
+// CGAL slicer
+#include <CGAL/Polygon_mesh_slicer.h>
+
 /**
  * @brief Slice a mesh with a set of planes defined by points and normals.
  *

--- a/src/straight_skeleton_2.h
+++ b/src/straight_skeleton_2.h
@@ -2,6 +2,16 @@
 
 #include "compas.h"
 
+// CGAL straight skeleton 2
+#include <CGAL/Polygon_2.h>
+#include <CGAL/create_straight_skeleton_2.h>
+#include <CGAL/create_straight_skeleton_from_polygon_with_holes_2.h>
+#include <CGAL/create_offset_polygons_2.h>
+#include <CGAL/create_weighted_offset_polygons_from_polygon_with_holes_2.h>
+#include <CGAL/create_weighted_straight_skeleton_2.h>
+#include <CGAL/create_offset_polygons_from_polygon_with_holes_2.h>
+
+
 /**
  * @brief Creates a straight skeleton from a simple polygon without holes.
  * 

--- a/src/subdivision.h
+++ b/src/subdivision.h
@@ -2,6 +2,9 @@
 
 #include "compas.h"
 
+// CGAL subdivision
+#include <CGAL/subdivision_method_3.h>
+
 /**
  * @brief Subdivide a mesh with the Catmull-Clark scheme.
  * 

--- a/src/triangulation.h
+++ b/src/triangulation.h
@@ -2,6 +2,20 @@
 
 #include "compas.h"
 
+// CGAL triangulation
+#include <CGAL/Delaunay_triangulation_2.h>
+#include <CGAL/Constrained_triangulation_2.h>
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Triangulation_vertex_base_with_info_2.h>
+#include <CGAL/Triangulation_face_base_with_info_2.h>
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Delaunay_mesher_2.h>
+#include <CGAL/Delaunay_mesh_vertex_base_2.h>
+#include <CGAL/Delaunay_mesh_face_base_2.h>
+#include <CGAL/Delaunay_mesh_size_criteria_2.h>
+#include <CGAL/Triangulation_conformer_2.h>
+#include <CGAL/lloyd_optimize_mesh_2.h>
+
 /**
  * @brief Delaunay Triangulation of a given set of points.
  * 


### PR DESCRIPTION
Changes:
- Turn off precompiled header for deployment
- Remove compas.h unnecessary std headers
- move back module specific headers to the source files, to decrease precompiled header from 1.6 gb to 0.8 gb.

During development precompiled headers can be turned ON by the following flag in the [CMakeLists.txt ](https://github.com/compas-dev/compas_cgal/blob/db1539101ba4b26a5f96db61af77755c8bea0e60/CMakeLists.txt):


```cmake
# =====================================================================
# Set this flag to ON for developing to increase build time.
# Set this flag to OFF for publishing for file size reduction.
# =====================================================================
option(ENABLE_PRECOMPILED_HEADERS "Enable precompiled headers for the build" ON)
```

Built time difference with Windows MSVC for precompiled headers from ~52 sec to ~2 seconds.
Without precompiled headers time stays the same ~52 sec.

File size with precompiled headers:

![image](https://github.com/user-attachments/assets/863137c4-83f7-4c53-8266-28750f3a7e6b)


Without precompiled headers overall sum of file size is smaller and split within the individual intermediate .obj files:
![image](https://github.com/user-attachments/assets/86b4bf01-ec3b-4b96-ba5e-d23b3d212712)


