### PR TITLE
Fix projection example imports from meshing to projection module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `docs/examples/example_booleans_with_edges.md` and `example_booleans_with_face_source.md` (with their images) covering the corefinement intersection-edge and face-source-tracking variants of the boolean operations; both wired into the Examples nav.
 * Added `docs/examples/example_boolean_difference_mesh_meshes.md` (CSG drilled rounded cube) and its Examples nav entry.
 
+### Fixed
+
+* Fixed `docs/examples/example_projection.py` imports: `project_mesh_on_mesh`, `project_points_on_mesh`, `pull_mesh_on_mesh`, and `pull_points_on_mesh` were incorrectly imported from `compas_cgal.meshing` instead of `compas_cgal.projection`, causing `ImportError` for anyone running the example.
+
 ### Changed
 
 * Bumped `nanobind` build-system requirement from `>=1.3.2` to `>=2.12` to fix `refined_delaunay_mesh` (and other `Eigen::Ref` overloads) raising `TypeError: incompatible function arguments` when called with `numpy>=2.4.0`.

--- a/docs/examples/example_projection.py
+++ b/docs/examples/example_projection.py
@@ -4,10 +4,10 @@ from compas.datastructures import Mesh
 from compas.geometry import Point
 from compas_viewer import Viewer
 
-from compas_cgal.meshing import project_mesh_on_mesh
-from compas_cgal.meshing import project_points_on_mesh
-from compas_cgal.meshing import pull_mesh_on_mesh
-from compas_cgal.meshing import pull_points_on_mesh
+from compas_cgal.projection import project_mesh_on_mesh
+from compas_cgal.projection import project_points_on_mesh
+from compas_cgal.projection import pull_mesh_on_mesh
+from compas_cgal.projection import pull_points_on_mesh
 
 # =============================================================================
 # Source


### PR DESCRIPTION
## Summary

- The functions `project_mesh_on_mesh`, `project_points_on_mesh`, `pull_mesh_on_mesh`, and `pull_points_on_mesh` were moved to `compas_cgal.projection` but the example still imported them from `compas_cgal.meshing`
- This causes an `ImportError` for anyone running the example or any package that follows it (e.g. `compas_dem`)
- Updated all 4 imports in `docs/examples/example_projection.py` to use the correct module

## Test plan

- [ ] Verify `from compas_cgal.projection import project_mesh_on_mesh` resolves correctly
- [ ] Run the example script to confirm no import errors